### PR TITLE
修复页码总页数显示有误问题

### DIFF
--- a/bnutils.sty
+++ b/bnutils.sty
@@ -15,6 +15,9 @@
     framexleftmargin=0.5em
 } 
 
+% 获取总页数(需要编译2次)
+\usepackage{lastpage}
+
 % 设置精确缩进
 \usepackage{paralist}
 


### PR DESCRIPTION
发现当前的 master 版本存在页码数字不正确的问题，显示效果大概为【第 9 页  共 ?? 页】。怀疑是没有用 lastpage 宏包的原因，因此在 bnutils.sty 中导入该宏包。虽然导入后实测总页数可以正常显示，但是需要编译 2 次才能够者却显示。其中第一次编译生成的 main.aux 不能删除，这样第二次编译生成的 main.pdf 页码才是正确的。